### PR TITLE
Fixed bug where last poll would be auto-attached to each new shoutout po...

### DIFF
--- a/views/default/forms/shoutout/edit.php
+++ b/views/default/forms/shoutout/edit.php
@@ -1,7 +1,7 @@
 <?php
 elgg_load_library('elgg:shoutout');
 $shoutout = $vars['entity'];
-if ($shoutout) {
+if ($shoutout instanceof ElggObject) {
 	$value = $shoutout->description;
 	$guid = $shoutout->guid;
 	$access_id = $shoutout->access_id;


### PR DESCRIPTION
For some reason, $vars['entity'] was being passed in as a stdObject with property num_items = 20. I've yet to find where that is coming from, but verifying that the entity is an ElggObject watches out for that.
